### PR TITLE
SWI-11188: fix YAML parse error in .bandwidth/component.yaml

### DIFF
--- a/.bandwidth/component.yaml
+++ b/.bandwidth/component.yaml
@@ -3,7 +3,7 @@ kind: Component
 metadata:
   schemaVersion: v1.0.0
   name: numbers-java-sdk
-  description: This SDK is no longer supported by Bandwidth and has been deprecated. Please use the SDK found here instead: https://github.com/Bandwidth/java-bandwidth-iris
+  description: "This SDK is no longer supported by Bandwidth and has been deprecated. Please use the SDK found here instead: https://github.com/Bandwidth/java-bandwidth-iris"
   annotations:
     github.com/project-slug: Bandwidth/numbers-java-sdk
     organization: BW


### PR DESCRIPTION
The `description` value contains a URL with colons which causes a YAML parse error, preventing this component from appearing in the Backstage catalog.

Fix: wrap the description value in double quotes.

Ref: SWI-11188