### PR TITLE
Sync bandwidth.com/languages annotation to Backstage catalog

### DIFF
--- a/.bandwidth/component.yaml
+++ b/.bandwidth/component.yaml
@@ -6,6 +6,7 @@ metadata:
   description: "This SDK is no longer supported by Bandwidth and has been deprecated. Please use the SDK found here instead: https://github.com/Bandwidth/java-bandwidth-iris"
   annotations:
     github.com/project-slug: Bandwidth/numbers-java-sdk
+    bandwidth.com/languages: Java
     organization: BW
     costCenter: Development - Software Infra
 spec:


### PR DESCRIPTION
Syncs the `bandwidth.com/languages` annotation in `.bandwidth/component.yaml` to match the repository's actual detected languages.

See: https://bandwidth-jira.atlassian.net/browse/SWI-11736

**Language change:** `(none)` → `Java`